### PR TITLE
Resolve inttoptr error

### DIFF
--- a/datagen/vex2llvm/LLVMCPYBlockSlicer.py
+++ b/datagen/vex2llvm/LLVMCPYBlockSlicer.py
@@ -141,21 +141,21 @@ class LLVMCPYBlockSlicer(object):
             my_bb_insts = list(stmt.instruction_parent.iter_instructions())
             my_index_in_bb = my_bb_insts.index(stmt)
             stmts_in_my_bb_with_index = [(my_bb_insts.index(x[1]), x[1]) for x in other_stmts_from_my_bb]
-            # stmts_in_my_bb_with_index_before_me = [x for x in stmts_in_my_bb_with_index if x[0] < my_index_in_bb]#store指令在前面
-            stmts_in_my_bb_with_index_before_me = [x for x in stmts_in_my_bb_with_index if x[0] > my_index_in_bb]#store指令在后面
+            stmts_in_my_bb_with_index_before_me = [x for x in stmts_in_my_bb_with_index if x[0] > my_index_in_bb]
             if len(stmts_in_my_bb_with_index_before_me) > 0:
                 return max(stmts_in_my_bb_with_index_before_me, key=lambda x: x[0])[1]
 
         # if we are here there are no insts in my bb before me..
-        other_stmts_from_prev_bbs = [x for x in other_stmts_bb_indices if x[0] > my_bb_subpath_index]#store指令所在块在inttoptr指令之前
+        other_stmts_from_prev_bbs = [x for x in other_stmts_bb_indices if x[0] > my_bb_subpath_index]
         if len(other_stmts_from_prev_bbs) > 0:
-            max_bb_index = max(other_stmts_from_prev_bbs, key=lambda x: x[0])[0]#得到最近一次store指令
+            max_bb_index = max(other_stmts_from_prev_bbs, key=lambda x: x[0])[0]
             stmts_in_prev_bb = [x for x in other_stmts_from_prev_bbs if x[0] == max_bb_index]
             prev_bb_insts = list(self._sub_path[max_bb_index].iter_instructions())
             indices_for_stmts_in_prev_bb = [(prev_bb_insts.index(x[1]), x[1]) for x in stmts_in_prev_bb]
-            return max(indices_for_stmts_in_prev_bb, key=lambda x:[0])[1]#返回最近的store指令
+            return max(indices_for_stmts_in_prev_bb, key=lambda x:[0])[1]
         else:
             return None
+
 
     def get_closest_write(self, stmt, other_stmts):
         my_bb_subpath_index = self._sub_path.index(stmt.instruction_parent)
@@ -166,12 +166,12 @@ class LLVMCPYBlockSlicer(object):
             my_bb_insts = list(stmt.instruction_parent.iter_instructions())
             my_index_in_bb = my_bb_insts.index(stmt)
             stmts_in_my_bb_with_index = [(my_bb_insts.index(x[1]), x[1]) for x in other_stmts_from_my_bb]
-            stmts_in_my_bb_with_index_before_me = [x for x in stmts_in_my_bb_with_index if x[0] > my_index_in_bb]
+            stmts_in_my_bb_with_index_before_me = [x for x in stmts_in_my_bb_with_index if x[0] < my_index_in_bb]
             if len(stmts_in_my_bb_with_index_before_me) > 0:
                 return max(stmts_in_my_bb_with_index_before_me, key=lambda x: x[0])[1]
 
         # if we are here there are no insts in my bb before me..
-        other_stmts_from_prev_bbs = [x for x in other_stmts_bb_indices if x[0] > my_bb_subpath_index]
+        other_stmts_from_prev_bbs = [x for x in other_stmts_bb_indices if x[0] < my_bb_subpath_index]
         if len(other_stmts_from_prev_bbs) > 0:
             max_bb_index = max(other_stmts_from_prev_bbs, key=lambda x: x[0])[0]
             stmts_in_prev_bb = [x for x in other_stmts_from_prev_bbs if x[0] == max_bb_index]


### PR DESCRIPTION
Athough it is simplify and ugly,  It can resolve some error.

It can get follow result
```
[(-56, 'ptr_strand'), (%arg.rsp, 'ptr_strand'), (  %ob0.t19 = add %arg.rsp, -56, 'ptr_strand'), (%arg.rsi, 'value_strand'), (  store %arg.rsi, %.143, 'value_strand'), (  %.143 = inttoptr %ob0.t19, 'value_strand'), (  %ob2.t17 = load %.143, 'value_strand')]
```
The file of `.ll` content is following.
```
define i64 @hashtab_find(i64 %arg.rax, i64 %arg.rbp, i64 %arg.rsp, i64 %arg.rdi, i64 %arg.rsi, i64 %arg.rdx, i64 %arg.cc_op, i64 %arg.cc_dep1, i64 %arg.cc_dep2, i64 %arg.cc_ndep, i64 %arg.rip, i64 %arg.rcx) local_unnamed_addr {
ob-1.initialize:
  %ob0.t13 = add i64 %arg.rsp, -8
  %.134 = inttoptr i64 %ob0.t13 to i64*
  store i64 %arg.rbp, i64* %.134, align 4
  %ob0.t16 = add i64 %arg.rsp, -48
  %.141 = inttoptr i64 %ob0.t16 to i64*
  store i64 %arg.rdi, i64* %.141, align 4
  %ob0.t19 = add i64 %arg.rsp, -56
  %.143 = inttoptr i64 %ob0.t19 to i64*
  store i64 %arg.rsi, i64* %.143, align 4
  %ob0.t22 = add i64 %arg.rsp, -60
  %ob0.t24 = trunc i64 %arg.rdx to i32
  %.145 = inttoptr i64 %ob0.t22 to i32*
  store i32 %ob0.t24, i32* %.145, align 4
  %ob0.t28 = load i64, i64* %.141, align 4
  %ob0.t29 = add i64 %ob0.t28, 24
  %.149 = inttoptr i64 %ob0.t29 to i64*
  %ob0.t31 = load i64, i64* %.149, align 4
  %ob0.t37 = tail call i64 @hashtab_find.amd64g_calculate_condition.5(i64 4, i64 20, i64 %ob0.t31, i64 0, i64 %arg.cc_ndep)
  %0 = and i64 %ob0.t37, 1
  %ob0.t32 = icmp eq i64 %0, 0
  br i1 %ob0.t32, label %ob2, label %ob9

ob2:                                              ; preds = %ob-1.initialize
  %ob2.t6 = load i64, i64* %.141, align 4
  %ob2.t7 = add i64 %ob2.t6, 32
  %.69 = inttoptr i64 %ob2.t7 to i32*
  %ob2.t10 = load i32, i32* %.69, align 4
  %ob2.t9 = zext i32 %ob2.t10 to i64
  %ob2.t14 = load i32, i32* %.145, align 4
  %ob2.t13 = zext i32 %ob2.t14 to i64
  %ob2.t17 = load i64, i64* %.143, align 4
  %.80 = tail call i64 @hashtab_find.Nget_key_len.3(i64 %ob2.t17, i64 %ob2.t13, i64 %ob2.t9)
```